### PR TITLE
Update JupyterLab config to disable trash

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.github/workflows/check-image.yml
+++ b/.github/workflows/check-image.yml
@@ -1,6 +1,6 @@
 name: Build and check image
 
-on: [push, pull_request]
+on: push
 
 jobs:
   verify-image-build:

--- a/.osparc/metadata.yml
+++ b/.osparc/metadata.yml
@@ -2,7 +2,7 @@ name: Jupyterlab Julia
 key: simcore/services/dynamic/jupyterlab-julia
 type: dynamic
 integration-version: 2.0.0
-version: 1.0.1
+version: 1.0.2
 description: JupyterLab coding environment for creating interactive Jupyter Notebooks with Julia (or Python)
 contact: iavarone@itis.swiss
 thumbnail: https://ih1.redbubble.net/image.1456778886.5914/bg,f8f8f8-flat,750x,075,f-pad,750x1000,f8f8f8.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## [1.0.2] - 6 May 2025
+### Fixed
+- Do not create `.Trash-1000` folder (caused service to fail after re-opening a study) ([#1296](https://github.com/ITISFoundation/osparc-issues/issues/1296))
 ## [1.0.1] - 23 Apr. 2024
 - First version

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export VCS_STATUS := $(if $(shell git status -s 2> /dev/null || echo unversioned
 export BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 export DOCKER_IMAGE_NAME ?= jupyterlab-julia
-export DOCKER_IMAGE_TAG ?= 1.0.1
+export DOCKER_IMAGE_TAG ?= 1.0.2
 
 OSPARC_DIR:=$(CURDIR)/.osparc
 

--- a/boot_scripts/boot_notebook.bash
+++ b/boot_scripts/boot_notebook.bash
@@ -49,7 +49,8 @@ cat > .jupyter_config.json <<EOF
         "token": "${NOTEBOOK_TOKEN}"
     },
     "FileContentsManager": {
-        "preferred_dir": "${NOTEBOOK_BASE_DIR}/workspace/"
+        "preferred_dir": "${NOTEBOOK_BASE_DIR}/workspace/",
+        "delete_to_trash": false
     }
 }
 EOF

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,6 +1,6 @@
 services:
   jupyterlab-julia:
-    image: simcore/services/dynamic/jupyterlab-julia:1.0.1
+    image: simcore/services/dynamic/jupyterlab-julia:1.0.2
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
## Problem
In recent Jupyterlab-based services, including the ones created with the new [cookiecutter for jupyterlabs](https://github.com/ITISFoundation/cookiecutter-osparc-jupyterlab-service), when the user deleted a file in the Jupyter UI, a `.Trash-1000` folder is created. Given the permissions on this folder, we can't push it to S3. More details in https://github.com/ITISFoundation/osparc-issues/issues/1296

## Investigations
It is not clear why this happens only in the newest Jupyters and not on other (e.g. jupyter-math). The "Trash" feature in jupyter seems relatively old (see https://github.com/jupyter/notebook/pull/1968).

## Solution
The JupyterLab Trash feature can be disabled via config. This is the only way I found to solve the issue, the only implication for the user is that if they delete a file via the UI, they won't be asked confirmation (it will work in the same way as deleting via the terminal with `rm`).

## Services affected
- jupyterlab-julia (this PR)
- jupyterlab-R
- cookiecutter for jupyters


## Related issues
related to: https://github.com/ITISFoundation/osparc-issues/issues/1296. All the services listed above need to be fixed to resolve the issue